### PR TITLE
Deployment with Now

### DIFF
--- a/.nowignore
+++ b/.nowignore
@@ -1,0 +1,1 @@
+node_modules

--- a/now.json
+++ b/now.json
@@ -1,0 +1,33 @@
+{
+    "version": 2,
+    "name": "itunes-api-react",
+    "builds": [
+      {
+        "src": "package.json",
+        "use": "@now/static-build",
+        "config": { "distDir": "build" }
+      }
+    ],
+    "routes": [
+      {
+        "src": "/static/(.*)",
+        "headers": { "cache-control": "s-maxage=31536000,immutable" },
+        "dest": "/static/$1"
+      },
+      { "src": "/asset-manifest.json", "dest": "/asset-manifest.json" },
+      { "src": "/manifest.json", "dest": "/manifest.json" },
+      { "src": "/precache-manifest.(.*)", "dest": "/precache-manifest.$1" },
+      { "src": "/robots.txt", "dest": "/robots.txt" },
+      { "src": "/.htaccess", "dest": "/.htaccess" },
+      {
+        "src": "/service-worker.js",
+        "headers": { "cache-control": "s-maxage=0" },
+        "dest": "/service-worker.js"
+      },
+      {
+        "src": "/(.*)",
+        "headers": { "cache-control": "s-maxage=0" },
+        "dest": "/index.html"
+      }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "now-build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
Add .nowignore (to ignore node modules);
add now.json (configurations for the deployment);
add a now-build script to package.json

// Documentation: https://zeit.co/now